### PR TITLE
Prepare release 3.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.16] - 2019-01-14
+### Changed
+- Se elimina la condición de VCI == "TSY" || VCI == "" para evaluar la respuesta de getTransactionResult debido a que
+esto podría traer problemas con transacciones usando tarjetas internacionales.
+
 ## [3.0.15] - 2018-12-27
 ### Fixed
 - Corrige creación de url para webpay.


### PR DESCRIPTION
CHANGED: Se elimina la condición de VCI == "TSY" || VCI == "" para
evaluar la respuesta de `getTransactionResult` debido a que esto podría
traer problemas con transacciones usando tarjetas internacionales.

You can see full changes here https://github.com/TransbankDevelopers/transbank-plugin-prestashop-webpay/compare/v3.0.15...chore/prepare-release-3.0.16