### PR TITLE
Send the plugin version on production environment

### DIFF
--- a/webpay/libwebpay/HealthCheck.php
+++ b/webpay/libwebpay/HealthCheck.php
@@ -159,7 +159,7 @@ class HealthCheck {
 
     // creacion de retornos
     // arma array que entrega informacion del ecommerce: nombre, version instalada, ultima version disponible
-    private function getPluginInfo($ecommerce) {
+    public function getPluginInfo($ecommerce) {
         $data = $this->getEcommerceInfo($ecommerce);
         $result = array(
             'ecommerce' => $ecommerce,

--- a/webpay/libwebpay/Telemetry/PluginVersion.php
+++ b/webpay/libwebpay/Telemetry/PluginVersion.php
@@ -1,0 +1,35 @@
+<?php
+namespace Transbank\Telemetry;
+
+class PluginVersion
+{
+    protected $soapUri = 'http://www.cumbregroup.com/tbk-webservice/PluginVersion.php?wsdl';
+    protected $client;
+    
+    const ENV_INTEGRATION = 'INTEGRACION';
+    const ENV_PRODUCTION = 'PRODUCCION';
+    const PRODUCT_WEBPAY = 1;
+    
+    const ECOMMERCE_WOOCOMMERCE = 1;
+    const ECOMMERCE_PRESTASHOP = 2;
+    const ECOMMERCE_MAGENTO2 = 3;
+    const ECOMMERCE_VIRTUEMART = 4;
+    const ECOMMERCE_OPENCART = 5;
+    const ECOMMERCE_SDK = 6;
+    /**
+     * PluginVersion constructor.
+     */
+    public function __construct()
+    {
+        $this->client = new \SoapClient($this->soapUri);
+    }
+    
+    public function registerVersion($commerceCode, $pluginVersion, $ecommerceVersion, $ecommerceId, $environment = self::ENV_PRODUCTION, $product = self::PRODUCT_WEBPAY)
+    {
+        try {
+            return $this->client->version_register($commerceCode, $pluginVersion, $ecommerceVersion, $ecommerceId, $environment, $product);
+        } catch (\Exception $e) {
+            // Si la conexión falla, simplemente no hacer nada.
+        }
+    }
+}

--- a/webpay/upgrade/upgrade-3.2.0.php
+++ b/webpay/upgrade/upgrade-3.2.0.php
@@ -28,15 +28,12 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-/**
- * This function updates your module from previous versions to the version 1.1,
- * usefull when you modify your database, or register a new hook ...
- * Don't forget to create one file per version.
- */
-function upgrade_module_1_1_0($module) {
-    /**
-     * Do everything you want right there,
-     * You could add a column in one of your module's tables
-     */
+function upgrade_module_3_2($module) {
+    
+    if (Configuration::get('WEBPAY_AMBIENT') === 'PRODUCCION') {
+        $webpayModule = new WebPay();
+        $config = $webpayModule->getConfigForHealthCheck();
+        $webpayModule->sendPluginVersion($config);
+    }
     return true;
 }


### PR DESCRIPTION
When the user updates the settings page of the plugin, if the environment is set to PRODUCCION, then the plugins sends the plugin version, the wocoommerce version and the commerce code to a internal telemetry API.

