### PR TITLE
Solucionado error de depencias de tcpdf

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -29,7 +29,14 @@ zip -FSr $PLUGIN_FILE $SRC_DIR -x webpay/vendor/tecnickcom/tcpdf/fonts/a*\/* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/f*\/* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/a* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/ci* \
-                                    webpay/vendor/tecnickcom/tcpdf/fonts/d* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavu-* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusansb* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusansc* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusanse* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusansi* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusansm* \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavusans.z \
+                                    webpay/vendor/tecnickcom/tcpdf/fonts/dejavuser* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/f* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/k* \
                                     webpay/vendor/tecnickcom/tcpdf/fonts/m* \


### PR DESCRIPTION
## Bug

Error que no permite generar comprobantes en pdf por falta de dependencias en la librería TCPDF.

Al descargar el comprobante desde el panel de administración/cliente se genera el siguiente error:

```
TCPDF error: Could not include font definition file: dejavusans.php
TCPDF error: Could not include font definition file: dejavusansi.ctg.z
```

## Versión

- Plugin: 3.1.2
- Prestashop: 1.7.6.7
- PHP: 7.2

## Causa del error

El archivo `package.sh` excluye los archivos mencionados en el proceso de creación del zip.

## Posible solución

Modificar el archivo `package.sh` de tal manera que no se excluyan las dependencias necesarias.


